### PR TITLE
Update skip paths

### DIFF
--- a/config/lura.go
+++ b/config/lura.go
@@ -80,7 +80,7 @@ func FromLura(srvCfg config.ServiceConfig) (*Config, error) {
 		// if there are no defined skip paths, we use the default ones:
 		// to avoid using defaultSkipPaths, provide a list with an empty string
 		cfg.SkipPaths = []string{
-			"/health",
+			"/__health",
 			"/__debug/",
 			"/__echo/",
 			"/__stats/",

--- a/config/lura.go
+++ b/config/lura.go
@@ -80,10 +80,10 @@ func FromLura(srvCfg config.ServiceConfig) (*Config, error) {
 		// if there are no defined skip paths, we use the default ones:
 		// to avoid using defaultSkipPaths, provide a list with an empty string
 		cfg.SkipPaths = []string{
-			"/healthz",
-			"/_ah/health",
-			"/__debug",
-			"/__echo",
+			"/health",
+			"/__debug/",
+			"/__echo/",
+			"/__stats/",
 		}
 	}
 


### PR DESCRIPTION
Update the default paths that should not be instrumented with open telemetry.