### PR TITLE
fix: assign correct span kinds

### DIFF
--- a/http/client/transport_traces.go
+++ b/http/client/transport_traces.go
@@ -53,7 +53,7 @@ func (t *transportTraces) start(rtt *roundTripTracking,
 		return
 	}
 
-	ctx, span := t.tracer.Start(rtt.req.Context(), t.spanName)
+	ctx, span := t.tracer.Start(rtt.req.Context(), t.spanName, trace.WithSpanKind(trace.SpanKindClient))
 	if span == nil || !span.IsRecording() {
 		// we might not be recording because of sampling
 		return

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -38,7 +38,7 @@ func (t *tracesHTTP) start(r *http.Request, tr *tracking) *http.Request {
 	if t == nil || t.tracer == nil || r.URL == nil {
 		return r
 	}
-	tr.ctx, tr.span = t.tracer.Start(r.Context(), r.URL.Path)
+	tr.ctx, tr.span = t.tracer.Start(r.Context(), r.URL.Path, trace.WithSpanKind(trace.SpanKindServer))
 	r = r.WithContext(tr.ctx)
 	attrs := otelhttp.TraceRequestAttrs(r)
 	tr.span.SetAttributes(attrs...)


### PR DESCRIPTION
Fixes https://github.com/krakend/krakend-otel/issues/5.

By assigning the correct `SpanKind` to the server and client spans, Datadog now shows different operation names:

<img width="541" alt="Screenshot 2024-03-15 at 4 15 53 PM" src="https://github.com/krakend/krakend-otel/assets/108835018/14bb196e-f2c7-4b50-b417-d8c76cc3c01f">

<img width="571" alt="Screenshot 2024-03-15 at 4 16 01 PM" src="https://github.com/krakend/krakend-otel/assets/108835018/e0e97e9c-ffdf-4d0a-844b-c8abf8117198">
