### PR TITLE
fix: add OTEL resource info to metrics

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,7 +6,7 @@ In the `docker_compose` folder there is the environment to run the observability
 
 ```
 make image
-cd docker-compose && make up
+cd docker_compose && make up
 ```
 
 ## Run local krakend instances and other services in docker compose

--- a/state/state.go
+++ b/state/state.go
@@ -83,6 +83,7 @@ func NewWithVersion(serviceName string, cfg *OTELStateConfig, version string,
 	var meterProvider metric.MeterProvider = noopmetric.NewMeterProvider()
 	var sdkMeterProvider *sdkmetric.MeterProvider
 	if len(metricOpts) > 0 {
+		metricOpts = append(metricOpts, sdkmetric.WithResource(res))
 		sdkMeterProvider = sdkmetric.NewMeterProvider(metricOpts...)
 		meterProvider = sdkMeterProvider
 	}


### PR DESCRIPTION
fixed `resource` info not being added to metrics as labels.
problem described in https://github.com/krakend/krakend-otel/issues/10

tested with the local setup and OTEL collector:

<img width="1425" alt="image" src="https://github.com/krakend/krakend-otel/assets/28865962/f27295e2-b92d-49c3-b726-32f1b76e4094">

\+ fixed the README instruction for the local setup, as the folder name with `docker-compose`-related files was previously renamed.
