### PR TITLE
Fix bad interface conversion

### DIFF
--- a/http/server/response_writer.go
+++ b/http/server/response_writer.go
@@ -82,12 +82,14 @@ func (w *TrackingResponseWriter) Flush() {
 func newTrackingResponseWriter(rw http.ResponseWriter, t *tracking, recordHeaders bool,
 	hijackCallback func(net.Conn, error) (net.Conn, error),
 ) *TrackingResponseWriter {
+	flusher, _ := rw.(http.Flusher)
+	hijacker, _ := rw.(http.Hijacker)
 	return &TrackingResponseWriter{
 		track:          t,
 		recordHeaders:  recordHeaders,
 		rw:             rw,
-		flusher:        rw.(http.Flusher),
-		hijacker:       rw.(http.Hijacker),
+		flusher:        flusher,
+		hijacker:       hijacker,
 		hijackCallback: hijackCallback,
 	}
 }

--- a/http/server/tracking.go
+++ b/http/server/tracking.go
@@ -50,7 +50,8 @@ func newTracking() *tracking {
 func fromContext(ctx context.Context) *tracking {
 	v := ctx.Value(krakenDContextTrackingStrKey)
 	if v != nil {
-		return v.(*tracking)
+		t, _ := v.(*tracking)
+		return t
 	}
 	return nil
 }


### PR DESCRIPTION
Avoid panics when converting interfaces. Looked for similar issues in the code, and checked that `nil` values when the values do not comply with the interface are handled as expected.