### PR TITLE
Global layer skip paths

### DIFF
--- a/example/client/make_skip_paths_requests.sh
+++ b/example/client/make_skip_paths_requests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+for i in {1..1000}
+do
+    # curl localhost:54444/fake/fsf
+    # curl localhost:54444/combination/2
+    echo -e "\n/__stats/"
+    curl localhost:54444/__stats/
+    echo -e "\n/__health"
+    curl localhost:54444/__health
+    echo -e "\n/__echo/"
+    curl localhost:54444/__echo/
+    # uncomment this to see real 404 not found error codes
+    # echo -e "\n/this_does_not_exist/"
+    # curl localhost:54444/this_does_not_exist/
+    echo -e "\n----\n"
+    sleep 1
+done

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -19,9 +19,15 @@ type trackingHandler struct {
 	metrics       *metricsHTTP
 	traces        *tracesHTTP
 	reportHeaders bool
+	config        *state.Config
 }
 
 func (h *trackingHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.URL != nil && h.config.SkipEndpoint(r.URL.Path) {
+		h.next.ServeHTTP(rw, r)
+		return
+	}
+
 	t := newTracking()
 	t.ctx = r.Context()
 	if h.prop != nil {
@@ -84,5 +90,6 @@ func NewTrackingHandler(next http.Handler) http.Handler {
 		metrics:       m,
 		traces:        t,
 		reportHeaders: gCfg.ReportHeaders,
+		config:        otelCfg,
 	}
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -19,7 +19,7 @@ type trackingHandler struct {
 	metrics       *metricsHTTP
 	traces        *tracesHTTP
 	reportHeaders bool
-	config        *state.Config
+	config        state.Config
 }
 
 func (h *trackingHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes #9 
The SkipPaths are checked "verbatim" at the global http layer too, meaning, that no params are replaced or pattern matched before comparison. 
Added a script to check that 404 does not happen anymore for `skip_paths` and that other 404 are reported as expected. 