### PR TITLE
Support global and per endpoint / backend static attributes in all layers 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,20 +138,22 @@ type LayersOpts struct {
 // We can select if we want to disable the metrics,
 // the traces, and / or the trace propagation.
 type GlobalOpts struct {
-	DisableMetrics     bool       `json:"disable_metrics"`
-	DisableTraces      bool       `json:"disable_traces"`
-	DisablePropagation bool       `json:"disable_propagation"`
-	ReportHeaders      bool       `json:"report_headers"`
-	StaticAttributes   Attributes `json:"static_attributes"`
+	DisableMetrics          bool       `json:"disable_metrics"`
+	DisableTraces           bool       `json:"disable_traces"`
+	DisablePropagation      bool       `json:"disable_propagation"`
+	ReportHeaders           bool       `json:"report_headers"`
+	MetricsStaticAttributes Attributes `json:"metrics_static_attributes"`
+	TracesStaticAttributes  Attributes `json:"traces_static_attributes"`
 }
 
 // PipeOpts has the options for the KrakenD pipe stage
 // to disable metrics and traces.
 type PipeOpts struct {
-	DisableMetrics     bool       `json:"disable_metrics"`
-	DisableTraces      bool       `json:"disable_traces"`
-	ReportHeaders      bool       `json:"report_headers"`
-	StaticAttributes   Attributes `json:"static_attributes"`
+	DisableMetrics          bool       `json:"disable_metrics"`
+	DisableTraces           bool       `json:"disable_traces"`
+	ReportHeaders           bool       `json:"report_headers"`
+	MetricsStaticAttributes Attributes `json:"metrics_static_attributes"`
+	TracesStaticAttributes  Attributes `json:"traces_static_attributes"`
 }
 
 // Enabled returns if either metrics or traces are enabled

--- a/config/config.go
+++ b/config/config.go
@@ -138,18 +138,20 @@ type LayersOpts struct {
 // We can select if we want to disable the metrics,
 // the traces, and / or the trace propagation.
 type GlobalOpts struct {
-	DisableMetrics     bool `json:"disable_metrics"`
-	DisableTraces      bool `json:"disable_traces"`
-	DisablePropagation bool `json:"disable_propagation"`
-	ReportHeaders      bool `json:"report_headers"`
+	DisableMetrics     bool       `json:"disable_metrics"`
+	DisableTraces      bool       `json:"disable_traces"`
+	DisablePropagation bool       `json:"disable_propagation"`
+	ReportHeaders      bool       `json:"report_headers"`
+	StaticAttributes   Attributes `json:"static_attributes"`
 }
 
 // PipeOpts has the options for the KrakenD pipe stage
 // to disable metrics and traces.
 type PipeOpts struct {
-	DisableMetrics bool `json:"disable_metrics"`
-	DisableTraces  bool `json:"disable_traces"`
-	ReportHeaders  bool `json:"report_headers"`
+	DisableMetrics     bool       `json:"disable_metrics"`
+	DisableTraces      bool       `json:"disable_traces"`
+	ReportHeaders      bool       `json:"report_headers"`
+	StaticAttributes   Attributes `json:"static_attributes"`
 }
 
 // Enabled returns if either metrics or traces are enabled

--- a/config/lura.go
+++ b/config/lura.go
@@ -24,14 +24,8 @@ var ErrNoConfig = errors.New("no config found for opentelemetry")
 // In case no "Layers" config is provided, a set of defaults with
 // everything enabled will be used.
 func FromLura(srvCfg luraconfig.ServiceConfig) (*ConfigData, error) {
-	cfg := new(ConfigData)
-	tmp, ok := srvCfg.ExtraConfig[Namespace]
-	if !ok {
-		return nil, ErrNoConfig
-	}
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(tmp)
-	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
+	cfg, err := LuraExtraCfg(srvCfg.ExtraConfig)
+	if err != nil {
 		return nil, err
 	}
 
@@ -47,17 +41,21 @@ func FromLura(srvCfg luraconfig.ServiceConfig) (*ConfigData, error) {
 	return cfg, nil
 }
 
-func EndpointExtraCfg(endpointExtraCfg luraconfig.ExtraConfig) *ConfigData {
-	cfg := new(ConfigData)
-	tmp, ok := endpointExtraCfg[Namespace]
+func LuraExtraCfg(extraCfg luraconfig.ExtraConfig) (*ConfigData, error) {
+	tmp, ok := extraCfg[Namespace]
 	if !ok {
-		return nil
-	}
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(tmp)
-	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
-		return nil
+		return nil, ErrNoConfig
 	}
 
-	return cfg
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(tmp); err != nil {
+		return nil, err
+	}
+
+	cfg := new(ConfigData)
+	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
 }

--- a/config/lura.go
+++ b/config/lura.go
@@ -46,3 +46,18 @@ func FromLura(srvCfg luraconfig.ServiceConfig) (*ConfigData, error) {
 	cfg.UnsetFieldsToDefaults()
 	return cfg, nil
 }
+
+func EndpointExtraCfg(endpointExtraCfg luraconfig.ExtraConfig) *ConfigData {
+	cfg := new(ConfigData)
+	tmp, ok := endpointExtraCfg[Namespace]
+	if !ok {
+		return nil
+	}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(tmp)
+	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
+		return nil
+	}
+
+	return cfg
+}

--- a/config/lura.go
+++ b/config/lura.go
@@ -41,6 +41,8 @@ func FromLura(srvCfg luraconfig.ServiceConfig) (*ConfigData, error) {
 	return cfg, nil
 }
 
+// LuraExtraCfg extracts the extra config field for the namespace if
+// provided
 func LuraExtraCfg(extraCfg luraconfig.ExtraConfig) (*ConfigData, error) {
 	tmp, ok := extraCfg[Namespace]
 	if !ok {

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,8 +1,8 @@
 KRAKEND_LOCAL_IP ?= 192.168.1.12
 
-build:
+srv:
 	go build -o srv ./server
-.PHONY: build
+.PHONY: srv
 
 image:
 	docker build -f ./server/Dockerfile -t krakend-otel-example:latest ..

--- a/example/docker_compose/conf/krakend_back/configuration.json
+++ b/example/docker_compose/conf/krakend_back/configuration.json
@@ -28,6 +28,40 @@
         },
         {
             "endpoint": "/back_combination/{id}",
+            "extra_config": {
+            "telemetry/opentelemetry": {
+                "layers": {
+                    "global": {
+                        "metrics_static_attributes": [
+                            {
+                                "key": "my_metric_global_override_attr",
+                                "value": "my_metric_global_override_val"
+                            }
+                        ],
+                        "traces_static_attributes": [
+                            {
+                                "key": "my_trace_global_override_attr",
+                                "value": "my_trace_global_override_val"
+                            }
+                        ]
+                    },
+                    "proxy": {
+                        "metrics_static_attributes": [
+                            {
+                                "key": "my_metric_proxy_override_attr",
+                                "value": "my_metric_proxy_override_val"
+                            }
+                        ],
+                        ,
+                        "traces_static_attributes": [
+                            {
+                                "key": "my_trace_proxy_override_attr",
+                                "value": "my_trace_proxy_override_val"
+                            }
+                        ]
+                    }
+                }
+            },
             "backend": [
                 {
                     "host": [
@@ -37,6 +71,30 @@
                     "is_collection": true,
                     "mapping": {
                         "collection": "posts"
+                    },
+                    "extra_config": {
+                        "telemetry/opentelemetry": {
+                            "layers": {
+                                "backend": {
+                                    "metrics": {
+                                        "static_attributes": [
+                                            {
+                                                "key": "my_metric_backend_override_attr",
+                                                "value": "my_metric_backend_override_val"
+                                            }
+                                        ]
+                                    },
+                                    "traces": {
+                                        "static_attributes": [
+                                            {
+                                                "key": "my_trace_backend_override_attr",
+                                                "value": "my_trace_backend_override_val"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 {
@@ -60,12 +118,36 @@
                 "global": {
                     "disable_metrics": false,
                     "disable_traces": false,
-                    "disable_propagation": false
+                    "disable_propagation": false,
+                    "metrics_static_attributes": [
+                        {
+                            "key": "my_metric_global_attr",
+                            "value": "my_metric_global_val"
+                        }
+                    ],
+                    "traces_static_attributes": [
+                        {
+                            "key": "my_trace_global_attr",
+                            "value": "my_trace_global_val"
+                        }
+                    ]
                 },
                 "proxy": {
                     "disable_metrics": false,
-                    "disable_traces": false
-                }, 
+                    "disable_traces": false,
+                    "metrics_static_attributes": [
+                        {
+                            "key": "my_metric_proxy_attr",
+                            "value": "my_metric_proxy_val"
+                        }
+                    ],
+                    "traces_static_attributes": [
+                        {
+                            "key": "my_trace_proxy_attr",
+                            "value": "my_trace_proxy_val"
+                        }
+                    ]
+                },
                 "backend": {
                     "metrics": {
                         "disable_stage": false,
@@ -74,8 +156,8 @@
                         "detailed_connection": true,
                         "static_attributes": [
                             {
-                                "key": "my_metric_attr",
-                                "value": "my_metric_val"
+                                "key": "my_metric_backend_attr",
+                                "value": "my_metric_backend_val"
                             }
                         ]
                     },
@@ -86,8 +168,8 @@
                         "detailed_connection": true,
                         "static_attributes": [
                             {
-                                "key": "my_trace_attr",
-                                "value": "my_trace_val" 
+                                "key": "my_trace_backend_attr",
+                                "value": "my_trace_backend_val"
                             }
                         ]
                     }

--- a/http/server/metrics.go
+++ b/http/server/metrics.go
@@ -36,7 +36,7 @@ func (m *metricsHTTP) report(t *tracking, r *http.Request) {
 	if m == nil || m.latency == nil {
 		return
 	}
-	dynAttrs := t.staticAttrs
+	dynAttrs := t.metricsStaticAttrs
 	dynAttrs = append(dynAttrs, semconv.HTTPRoute(t.EndpointPattern()))
 	dynAttrs = append(dynAttrs, semconv.HTTPRequestMethodKey.String(r.Method))
 	dynAttrs = append(dynAttrs, semconv.HTTPResponseStatusCode(t.responseStatus))

--- a/http/server/metrics.go
+++ b/http/server/metrics.go
@@ -5,7 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 
 	kotelconfig "github.com/krakend/krakend-otel/config"
 )
@@ -36,11 +36,11 @@ func (m *metricsHTTP) report(t *tracking, r *http.Request) {
 	if m == nil || m.latency == nil {
 		return
 	}
-	dynAttrsOpts := metric.WithAttributes(
-		semconv.HTTPRoute(t.EndpointPattern()),
-		semconv.HTTPRequestMethodKey.String(r.Method),
-		semconv.HTTPResponseStatusCode(t.responseStatus),
-	)
+	dynAttrs := t.staticAttrs
+	dynAttrs = append(dynAttrs, semconv.HTTPRoute(t.EndpointPattern()))
+	dynAttrs = append(dynAttrs, semconv.HTTPRequestMethodKey.String(r.Method))
+	dynAttrs = append(dynAttrs, semconv.HTTPResponseStatusCode(t.responseStatus))
+	dynAttrsOpts := metric.WithAttributes(dynAttrs...)
 	m.latency.Record(t.ctx, t.latencyInSecs, m.fixedAttrsOpts, dynAttrsOpts)
 	m.size.Record(t.ctx, int64(t.responseSize), m.fixedAttrsOpts, dynAttrsOpts)
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -73,22 +73,29 @@ func NewTrackingHandler(next http.Handler) http.Handler {
 	}
 
 	// Add configured static attributes
-	attrs := []attribute.KeyValue{}
-	for _, kv := range gCfg.StaticAttributes {
+	metricsAttrs := []attribute.KeyValue{}
+	tracesAttrs := []attribute.KeyValue{}
+	for _, kv := range gCfg.MetricsStaticAttributes {
 		if len(kv.Key) > 0 && len(kv.Value) > 0 {
-			attrs = append(attrs, attribute.String(kv.Key, kv.Value))
+			metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
+		}
+	}
+
+	for _, kv := range gCfg.TracesStaticAttributes {
+		if len(kv.Key) > 0 && len(kv.Value) > 0 {
+			tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
 		}
 	}
 
 	var m *metricsHTTP
 	if !gCfg.DisableMetrics {
-		m = newMetricsHTTP(s.Meter(), attrs)
+		m = newMetricsHTTP(s.Meter(), metricsAttrs)
 	}
 
 	var t *tracesHTTP
 	if !gCfg.DisableTraces {
-		attrs = append(attrs, attribute.String("krakend.stage", "global"))
-		t = newTracesHTTP(s.Tracer(), attrs, gCfg.ReportHeaders)
+		tracesAttrs = append(tracesAttrs, attribute.String("krakend.stage", "global"))
+		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders)
 	}
 
 	return &trackingHandler{

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -72,29 +72,27 @@ func NewTrackingHandler(next http.Handler) http.Handler {
 		prop = s.Propagator()
 	}
 
-	// Add configured static attributes
-	metricsAttrs := []attribute.KeyValue{}
-	tracesAttrs := []attribute.KeyValue{}
-	for _, kv := range gCfg.MetricsStaticAttributes {
-		if len(kv.Key) > 0 && len(kv.Value) > 0 {
-			metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
-		}
-	}
-
-	for _, kv := range gCfg.TracesStaticAttributes {
-		if len(kv.Key) > 0 && len(kv.Value) > 0 {
-			tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
-		}
-	}
-
 	var m *metricsHTTP
 	if !gCfg.DisableMetrics {
+		var metricsAttrs []attribute.KeyValue
+		for _, kv := range gCfg.MetricsStaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+
 		m = newMetricsHTTP(s.Meter(), metricsAttrs)
 	}
 
 	var t *tracesHTTP
 	if !gCfg.DisableTraces {
-		tracesAttrs = append(tracesAttrs, attribute.String("krakend.stage", "global"))
+		tracesAttrs := []attribute.KeyValue{attribute.String("krakend.stage", "global")}
+		for _, kv := range gCfg.TracesStaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+
 		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders)
 	}
 

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -6,7 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	otelhttp "github.com/krakend/krakend-otel/http"
@@ -71,6 +71,7 @@ func (t *tracesHTTP) end(tr *tracking) {
 		semconv.HTTPRoute(tr.EndpointPattern()),
 		semconv.HTTPResponseStatusCode(tr.responseStatus),
 		semconv.HTTPResponseBodySize(tr.responseSize))
+	tr.span.SetAttributes(tr.tracesStaticAttrs...)
 
 	if tr.responseHeaders != nil {
 		// report all incoming headers

--- a/http/server/tracking.go
+++ b/http/server/tracking.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -28,6 +29,7 @@ type tracking struct {
 	writeErrs       []error
 	endpointPattern string
 	isHijacked      bool
+	staticAttrs     []attribute.KeyValue
 	hijackedErr     error
 }
 
@@ -39,6 +41,10 @@ func (t *tracking) EndpointPattern() string {
 		return "404 Not Found"
 	}
 	return t.endpointPattern
+}
+
+func (t *tracking) StaticAttributes() []attribute.KeyValue {
+	return t.staticAttrs
 }
 
 func newTracking() *tracking {
@@ -61,6 +67,12 @@ func fromContext(ctx context.Context) *tracking {
 func SetEndpointPattern(ctx context.Context, endpointPattern string) {
 	if t := fromContext(ctx); t != nil {
 		t.endpointPattern = endpointPattern
+	}
+}
+
+func SetStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
+	if t := fromContext(ctx); t != nil {
+		t.staticAttrs = attrs
 	}
 }
 

--- a/http/server/tracking.go
+++ b/http/server/tracking.go
@@ -75,15 +75,12 @@ func SetEndpointPattern(ctx context.Context, endpointPattern string) {
 	}
 }
 
-func SetMetricsStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
+// SetStaticAttributtes allows to set metrics and traces static attributes in
+// the request context
+func SetStaticAttributtes(ctx context.Context, metricAttrs, tracesAttrs []attribute.KeyValue) {
 	if t := fromContext(ctx); t != nil {
-		t.metricsStaticAttrs = attrs
-	}
-}
-
-func SetTracesStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
-	if t := fromContext(ctx); t != nil {
-		t.tracesStaticAttrs = attrs
+		t.metricsStaticAttrs = metricAttrs
+		t.tracesStaticAttrs = tracesAttrs
 	}
 }
 

--- a/http/server/tracking.go
+++ b/http/server/tracking.go
@@ -22,15 +22,16 @@ type tracking struct {
 	ctx       context.Context
 	span      trace.Span
 
-	latencyInSecs   float64
-	responseSize    int
-	responseStatus  int
-	responseHeaders map[string][]string
-	writeErrs       []error
-	endpointPattern string
-	isHijacked      bool
-	staticAttrs     []attribute.KeyValue
-	hijackedErr     error
+	latencyInSecs      float64
+	responseSize       int
+	responseStatus     int
+	responseHeaders    map[string][]string
+	writeErrs          []error
+	endpointPattern    string
+	isHijacked         bool
+	metricsStaticAttrs []attribute.KeyValue
+	tracesStaticAttrs  []attribute.KeyValue
+	hijackedErr        error
 }
 
 func (t *tracking) EndpointPattern() string {
@@ -43,8 +44,12 @@ func (t *tracking) EndpointPattern() string {
 	return t.endpointPattern
 }
 
-func (t *tracking) StaticAttributes() []attribute.KeyValue {
-	return t.staticAttrs
+func (t *tracking) MetricsStaticAttributes() []attribute.KeyValue {
+	return t.metricsStaticAttrs
+}
+
+func (t *tracking) TracesStaticAttributes() []attribute.KeyValue {
+	return t.tracesStaticAttrs
 }
 
 func newTracking() *tracking {
@@ -70,9 +75,15 @@ func SetEndpointPattern(ctx context.Context, endpointPattern string) {
 	}
 }
 
-func SetStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
+func SetMetricsStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
 	if t := fromContext(ctx); t != nil {
-		t.staticAttrs = attrs
+		t.metricsStaticAttrs = attrs
+	}
+}
+
+func SetTracesStaticAttributtes(ctx context.Context, attrs []attribute.KeyValue) {
+	if t := fromContext(ctx); t != nil {
+		t.tracesStaticAttrs = attrs
 	}
 }
 

--- a/lura/proxy.go
+++ b/lura/proxy.go
@@ -114,6 +114,14 @@ func ProxyFactory(pf proxy.Factory) proxy.FactoryFunc {
 			semconv.HTTPRequestMethodKey.String(cfg.Method),
 			semconv.HTTPRoute(urlPattern),
 		}
+
+		// Add configured static attributes
+		for _, kv := range pipeOpts.StaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				attrs = append(attrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+
 		return middleware(gs, !pipeOpts.DisableMetrics, !pipeOpts.DisableTraces,
 			"proxy", urlPattern, attrs, pipeOpts.ReportHeaders)(next), nil
 	}

--- a/lura/proxy.go
+++ b/lura/proxy.go
@@ -163,7 +163,23 @@ func BackendFactory(bf proxy.BackendFactory) proxy.BackendFactory {
 			attribute.String("krakend.endpoint.route", parentEndpoint),
 			attribute.String("krakend.endpoint.method", cfg.ParentEndpointMethod),
 		}
+
+		// Add configured static attributes
+		metricsAttrs := attrs
+		tracesAttrs := attrs
+		for _, kv := range backendOpts.Metrics.StaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+
+		for _, kv := range backendOpts.Traces.StaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+
 		return middleware(gs, !backendOpts.Metrics.DisableStage, !backendOpts.Traces.DisableStage,
-			"backend", urlPattern, attrs, attrs, backendOpts.Traces.ReportHeaders)(next)
+			"backend", urlPattern, metricsAttrs, tracesAttrs, backendOpts.Traces.ReportHeaders)(next)
 	}
 }

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -5,6 +5,7 @@ import (
 	luraconfig "github.com/luraproject/lura/v2/config"
 	"github.com/luraproject/lura/v2/proxy"
 	krakendgin "github.com/luraproject/lura/v2/router/gin"
+	"go.opentelemetry.io/otel/attribute"
 
 	kotelconfig "github.com/krakend/krakend-otel/config"
 	kotelserver "github.com/krakend/krakend-otel/http/server"
@@ -23,12 +24,29 @@ func New(hf krakendgin.HandlerFactory) krakendgin.HandlerFactory {
 		}
 		urlPattern := kotelconfig.NormalizeURLPattern(cfg.Endpoint)
 		next := hf(cfg, p)
+		attrs := getAttrib(cfg)
+
 		return func(c *gin.Context) {
 			// we set the matched route to a data struct stored in the
 			// context by the outer http layer, so it can be reported
 			// in metrics and traces.
 			kotelserver.SetEndpointPattern(c.Request.Context(), urlPattern)
+			kotelserver.SetStaticAttributtes(c.Request.Context(), attrs)
 			next(c)
 		}
 	}
+}
+
+func getAttrib(cfg *luraconfig.EndpointConfig) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	cfgExtra := kotelconfig.EndpointExtraCfg(cfg.ExtraConfig)
+	if cfgExtra != nil && cfgExtra.Layers.Global != nil {
+		for _, kv := range cfgExtra.Layers.Global.StaticAttributes {
+			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				attrs = append(attrs, attribute.String(kv.Key, kv.Value))
+			}
+		}
+	}
+
+	return attrs
 }

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -24,8 +24,8 @@ func New(hf krakendgin.HandlerFactory) krakendgin.HandlerFactory {
 		}
 		urlPattern := kotelconfig.NormalizeURLPattern(cfg.Endpoint)
 		next := hf(cfg, p)
-		metricsAttrs := []attribute.KeyValue{}
-		tracesAttrs := []attribute.KeyValue{}
+		var metricsAttrs []attribute.KeyValue
+		var tracesAttrs []attribute.KeyValue
 
 		cfgExtra, err := kotelconfig.LuraExtraCfg(cfg.ExtraConfig)
 		if err == nil && cfgExtra.Layers.Global != nil {
@@ -47,8 +47,7 @@ func New(hf krakendgin.HandlerFactory) krakendgin.HandlerFactory {
 			// context by the outer http layer, so it can be reported
 			// in metrics and traces.
 			kotelserver.SetEndpointPattern(c.Request.Context(), urlPattern)
-			kotelserver.SetMetricsStaticAttributtes(c.Request.Context(), metricsAttrs)
-			kotelserver.SetTracesStaticAttributtes(c.Request.Context(), tracesAttrs)
+			kotelserver.SetStaticAttributtes(c.Request.Context(), metricsAttrs, tracesAttrs)
 			next(c)
 		}
 	}

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -27,8 +27,8 @@ func New(hf krakendgin.HandlerFactory) krakendgin.HandlerFactory {
 		metricsAttrs := []attribute.KeyValue{}
 		tracesAttrs := []attribute.KeyValue{}
 
-		cfgExtra := kotelconfig.EndpointExtraCfg(cfg.ExtraConfig)
-		if cfgExtra != nil && cfgExtra.Layers.Global != nil {
+		cfgExtra, err := kotelconfig.LuraExtraCfg(cfg.ExtraConfig)
+		if err == nil && cfgExtra.Layers.Global != nil {
 			for _, kv := range cfgExtra.Layers.Global.MetricsStaticAttributes {
 				if len(kv.Key) > 0 && len(kv.Value) > 0 {
 					metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))

--- a/state/config.go
+++ b/state/config.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"github.com/krakend/krakend-otel/config"
-	kotelconfig "github.com/krakend/krakend-otel/config"
 	luraconfig "github.com/luraproject/lura/v2/config"
 )
 
@@ -42,16 +41,16 @@ func (*StateConfig) EndpointOTEL(_ *luraconfig.EndpointConfig) OTEL {
 
 func (s *StateConfig) EndpointPipeOpts(cfg *luraconfig.EndpointConfig) config.PipeOpts {
 	PipeOpts := *s.cfgData.Layers.Pipe
-	cfgExtra, err := kotelconfig.LuraExtraCfg(cfg.ExtraConfig)
+	cfgExtra, err := config.LuraExtraCfg(cfg.ExtraConfig)
 	if err == nil && cfgExtra.Layers.Pipe != nil {
 		PipeOpts.MetricsStaticAttributes = append(
 			PipeOpts.MetricsStaticAttributes,
-			cfgExtra.Layers.Global.MetricsStaticAttributes...,
+			cfgExtra.Layers.Pipe.MetricsStaticAttributes...,
 		)
 
 		PipeOpts.TracesStaticAttributes = append(
 			PipeOpts.TracesStaticAttributes,
-			cfgExtra.Layers.Global.TracesStaticAttributes...,
+			cfgExtra.Layers.Pipe.TracesStaticAttributes...,
 		)
 	}
 
@@ -73,7 +72,7 @@ func (s *StateConfig) BackendOpts(cfg *luraconfig.Backend) config.BackendOpts {
 func mergedBackendOpts(s *StateConfig, cfg *luraconfig.Backend) config.BackendOpts {
 	BackendOpts := *s.cfgData.Layers.Backend
 
-	cfgExtra, err := kotelconfig.LuraExtraCfg(cfg.ExtraConfig)
+	cfgExtra, err := config.LuraExtraCfg(cfg.ExtraConfig)
 	if err == nil && cfgExtra.Layers.Backend != nil {
 		if cfgExtra.Layers.Backend.Metrics != nil {
 			BackendOpts.Metrics.StaticAttributes = append(

--- a/state/config_test.go
+++ b/state/config_test.go
@@ -1,0 +1,225 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/krakend/krakend-otel/config"
+	luraconfig "github.com/luraproject/lura/v2/config"
+)
+
+func TestEndpointPipeConfigOverride(t *testing.T) {
+	globalMetricAttrs := makeGlobalMetricAttr()
+	overrideMetricAttrs := makeOverrideMetricAttr()
+	expectedMetricAttrs := append(globalMetricAttrs, overrideMetricAttrs...) // skipcq: CRT-D0001
+
+	globalTraceAttrs := makeGlobalTraceAttr()
+	overrideTraceAttrs := makeOverrideTraceAttr()
+	expectedTraceAttrs := append(globalTraceAttrs, overrideTraceAttrs...) // skipcq: CRT-D0001
+
+	stateCfg := &StateConfig{
+		cfgData: makePipeConf(globalMetricAttrs, globalTraceAttrs),
+	}
+
+	pipeCfg := &luraconfig.EndpointConfig{
+		ExtraConfig: map[string]interface{}{
+			"telemetry/opentelemetry": makePipeConf(overrideMetricAttrs, overrideTraceAttrs),
+		},
+	}
+
+	pipeOpts := stateCfg.EndpointPipeOpts(pipeCfg)
+
+	if len(pipeOpts.MetricsStaticAttributes) != len(expectedMetricAttrs) {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v - expected: %+v",
+			pipeOpts.MetricsStaticAttributes,
+			expectedMetricAttrs,
+		)
+	}
+
+	if len(pipeOpts.TracesStaticAttributes) != len(expectedTraceAttrs) {
+		t.Errorf(
+			"Incorrect number of attributes for traces. returned: %+v - expected: %+v",
+			pipeOpts.TracesStaticAttributes,
+			expectedTraceAttrs,
+		)
+	}
+}
+
+func TestEndpointPipeNoOverride(t *testing.T) {
+	stateCfg := &StateConfig{
+		cfgData: makePipeConf(makeGlobalMetricAttr(), makeGlobalTraceAttr()),
+	}
+
+	// Empty config
+	pipeCfg := &luraconfig.EndpointConfig{
+		ExtraConfig: map[string]interface{}{},
+	}
+
+	pipeOpts := stateCfg.EndpointPipeOpts(pipeCfg)
+
+	if len(pipeOpts.MetricsStaticAttributes) > 1 {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v",
+			pipeOpts.MetricsStaticAttributes,
+		)
+	}
+}
+
+func TestEndpointPipeConfigOnlyOverride(t *testing.T) {
+	stateCfg := &StateConfig{
+		cfgData: makePipeConf([]config.KeyValue{}, []config.KeyValue{}),
+	}
+
+	pipeCfg := &luraconfig.EndpointConfig{
+		ExtraConfig: map[string]interface{}{
+			"telemetry/opentelemetry": makePipeConf(makeOverrideMetricAttr(), makeOverrideTraceAttr()),
+		},
+	}
+
+	pipeOpts := stateCfg.EndpointPipeOpts(pipeCfg)
+
+	if len(pipeOpts.MetricsStaticAttributes) > 1 {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v",
+			pipeOpts.MetricsStaticAttributes,
+		)
+	}
+}
+
+func TestBackendConfigOverride(t *testing.T) {
+	globalMetricAttrs := makeGlobalMetricAttr()
+	overrideMetricAttrs := makeOverrideMetricAttr()
+	expectedMetricAttrs := append(globalMetricAttrs, overrideMetricAttrs...) // skipcq: CRT-D0001
+
+	globalTraceAttrs := makeGlobalTraceAttr()
+	overrideTraceAttrs := makeOverrideTraceAttr()
+	expectedTraceAttrs := append(globalTraceAttrs, overrideTraceAttrs...) // skipcq: CRT-D0001
+
+	stateCfg := &StateConfig{
+		cfgData: makeBackendConf(globalMetricAttrs, globalTraceAttrs),
+	}
+
+	backendCfg := &luraconfig.Backend{
+		ExtraConfig: map[string]interface{}{
+			"telemetry/opentelemetry": makeBackendConf(overrideMetricAttrs, overrideTraceAttrs),
+		},
+	}
+
+	backendOpts := stateCfg.BackendOpts(backendCfg)
+
+	if len(backendOpts.Metrics.StaticAttributes) != len(expectedMetricAttrs) {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v - expected: %+v",
+			backendOpts.Metrics.StaticAttributes,
+			expectedMetricAttrs,
+		)
+	}
+
+	if len(backendOpts.Traces.StaticAttributes) != len(expectedTraceAttrs) {
+		t.Errorf(
+			"Incorrect number of attributes for traces. returned: %+v - expected: %+v",
+			backendOpts.Traces.StaticAttributes,
+			expectedTraceAttrs,
+		)
+	}
+}
+
+func TestBackendConfigNoOverride(t *testing.T) {
+	stateCfg := &StateConfig{
+		cfgData: makeBackendConf(makeGlobalMetricAttr(), makeGlobalTraceAttr()),
+	}
+
+	// Empty config
+	backendCfg := &luraconfig.Backend{
+		ExtraConfig: map[string]interface{}{},
+	}
+
+	backendOpts := stateCfg.BackendOpts(backendCfg)
+
+	if len(backendOpts.Metrics.StaticAttributes) > 1 {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v",
+			backendOpts.Traces.StaticAttributes,
+		)
+	}
+}
+
+func TestBackendConfigOnlyOverride(t *testing.T) {
+	stateCfg := &StateConfig{
+		cfgData: makeBackendConf([]config.KeyValue{}, []config.KeyValue{}),
+	}
+
+	backendCfg := &luraconfig.Backend{
+		ExtraConfig: map[string]interface{}{
+			"telemetry/opentelemetry": makeBackendConf(makeOverrideMetricAttr(), makeOverrideTraceAttr()),
+		},
+	}
+
+	backendOpts := stateCfg.BackendOpts(backendCfg)
+
+	if len(backendOpts.Metrics.StaticAttributes) > 1 {
+		t.Errorf(
+			"Incorrect number of attributes for metrics. returned: %+v",
+			backendOpts.Traces.StaticAttributes,
+		)
+	}
+}
+
+func makePipeConf(metricAttrs, traceAttrs []config.KeyValue) config.ConfigData {
+	return config.ConfigData{
+		Layers: &config.LayersOpts{
+			Pipe: makePipeOpts(metricAttrs, traceAttrs),
+		},
+	}
+}
+
+func makePipeOpts(metricAttrs, traceAttrs []config.KeyValue) *config.PipeOpts {
+	return &config.PipeOpts{
+		MetricsStaticAttributes: metricAttrs,
+		TracesStaticAttributes:  traceAttrs,
+	}
+}
+
+func makeBackendConf(metricAttrs, traceAttrs []config.KeyValue) config.ConfigData {
+	return config.ConfigData{
+		Layers: &config.LayersOpts{
+			Backend: makeBackendOpts(metricAttrs, traceAttrs),
+		},
+	}
+}
+
+func makeBackendOpts(metricAttrs, traceAttrs []config.KeyValue) *config.BackendOpts {
+	return &config.BackendOpts{
+		Metrics: &config.BackendMetricOpts{
+			StaticAttributes: metricAttrs,
+		},
+		Traces: &config.BackendTraceOpts{
+			StaticAttributes: traceAttrs,
+		},
+	}
+}
+
+func makeGlobalMetricAttr() []config.KeyValue {
+	return makeStaticAttr("my_metric_key", "my_metric_value")
+}
+
+func makeOverrideMetricAttr() []config.KeyValue {
+	return makeStaticAttr("my_metric_override_key", "my_metric_override_value")
+}
+
+func makeGlobalTraceAttr() []config.KeyValue {
+	return makeStaticAttr("my_trace_key", "my_trace_value")
+}
+
+func makeOverrideTraceAttr() []config.KeyValue {
+	return makeStaticAttr("my_trace_override_key", "my_trace_override_value")
+}
+
+func makeStaticAttr(key, value string) []config.KeyValue {
+	return []config.KeyValue{
+		config.KeyValue{
+			Key:   key,
+			Value: value,
+		},
+	}
+}


### PR DESCRIPTION
## Description

This PR adds support for:

- Global static attributes for `global` and `proxy` layers
- Set per endpoint / backend static attributes. These will be merged with the globally provided ones if any

## Use Case

The main idea is to provide allow for better grouping when creating dashboards with the metrics.

## Approach

Two new fields were added to the `global` and `proxy` layers

- `metrics_static_attributes`
- `traces_static_attributes`

The reason for this option was that the configuration on these two layers was already flat (as opposed to the `backend` layer which has a `metrics` and `traces` section) , hence this keeps the convention already set. Also, changing to something like the `backend` layer could lead to some breaking changes.

__NOTE__: I don't have strong opinions on this format and I'm willing to adapt the PR to your preferred way to pass the configuration

Also, configuration provided in an endpoint of backend section will now be parsed to get static labels which will be merged with any other label provided at the top level of the configuration. All other configuration parameters provided will be ignored.