### PR TITLE
Remove the "layers" object in extra_config opentelemetry 

### DIFF
--- a/config/lura.go
+++ b/config/lura.go
@@ -61,3 +61,22 @@ func LuraExtraCfg(extraCfg luraconfig.ExtraConfig) (*ConfigData, error) {
 
 	return cfg, nil
 }
+
+func LuraLayerExtraCfg(extraCfg luraconfig.ExtraConfig) (*LayersOpts, error) {
+	tmp, ok := extraCfg[Namespace]
+	if !ok {
+		return nil, ErrNoConfig
+	}
+
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(tmp); err != nil {
+		return nil, err
+	}
+
+	cfg := new(LayersOpts)
+	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/example/docker_compose/conf/krakend_back/configuration.json
+++ b/example/docker_compose/conf/krakend_back/configuration.json
@@ -30,36 +30,20 @@
             "endpoint": "/back_combination/{id}",
             "extra_config": {
             "telemetry/opentelemetry": {
-                "layers": {
-                    "global": {
-                        "metrics_static_attributes": [
-                            {
-                                "key": "my_metric_global_override_attr",
-                                "value": "my_metric_global_override_val"
-                            }
-                        ],
-                        "traces_static_attributes": [
-                            {
-                                "key": "my_trace_global_override_attr",
-                                "value": "my_trace_global_override_val"
-                            }
-                        ]
-                    },
-                    "proxy": {
-                        "metrics_static_attributes": [
-                            {
-                                "key": "my_metric_proxy_override_attr",
-                                "value": "my_metric_proxy_override_val"
-                            }
-                        ],
-                        ,
-                        "traces_static_attributes": [
-                            {
-                                "key": "my_trace_proxy_override_attr",
-                                "value": "my_trace_proxy_override_val"
-                            }
-                        ]
-                    }
+                "proxy": {
+                    "metrics_static_attributes": [
+                        {
+                            "key": "my_metric_proxy_override_attr",
+                            "value": "my_metric_proxy_override_val"
+                        }
+                    ],
+                    ,
+                    "traces_static_attributes": [
+                        {
+                            "key": "my_trace_proxy_override_attr",
+                            "value": "my_trace_proxy_override_val"
+                        }
+                    ]
                 }
             },
             "backend": [
@@ -74,24 +58,22 @@
                     },
                     "extra_config": {
                         "telemetry/opentelemetry": {
-                            "layers": {
-                                "backend": {
-                                    "metrics": {
-                                        "static_attributes": [
-                                            {
-                                                "key": "my_metric_backend_override_attr",
-                                                "value": "my_metric_backend_override_val"
-                                            }
-                                        ]
-                                    },
-                                    "traces": {
-                                        "static_attributes": [
-                                            {
-                                                "key": "my_trace_backend_override_attr",
-                                                "value": "my_trace_backend_override_val"
-                                            }
-                                        ]
-                                    }
+                            "backend": {
+                                "metrics": {
+                                    "static_attributes": [
+                                        {
+                                            "key": "my_metric_backend_override_attr",
+                                            "value": "my_metric_backend_override_val"
+                                        }
+                                    ]
+                                },
+                                "traces": {
+                                    "static_attributes": [
+                                        {
+                                            "key": "my_trace_backend_override_attr",
+                                            "value": "my_trace_backend_override_val"
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/state/config.go
+++ b/state/config.go
@@ -59,7 +59,7 @@ func (s *StateConfig) EndpointPipeOpts(cfg *luraconfig.EndpointConfig) *config.P
 	}
 
 	cfgLayer, err := config.LuraLayerExtraCfg(cfg.ExtraConfig)
-	if err == nil && cfgLayer != nil {
+	if err == nil && cfgLayer != nil && cfgLayer.Pipe != nil {
 		opts = cfgLayer.Pipe
 	}
 
@@ -91,7 +91,7 @@ func (s *StateConfig) mergedBackendOpts(cfg *luraconfig.Backend) *config.Backend
 	}
 
 	cfgLayer, err := config.LuraLayerExtraCfg(cfg.ExtraConfig)
-	if err == nil && cfgLayer != nil {
+	if err == nil && cfgLayer != nil && cfgLayer.Backend != nil {
 		opts = cfgLayer.Backend
 	}
 


### PR DESCRIPTION
This PR adds the ability to override OTEL configuration for:

- **proxy** layer for a single endpoint (it does not allows to set **backend** layers, for this single endpoint.. if you want to override the backend layer, it must be done in each of its childs)
- **backend** for a single backend. 

The "overrides" **do not inherit parent configs**, so if for example, you only specify this in a config for a backend:
```json
{
                    "host": [
                        "https://jsonplaceholder.typicode.com"
                    ],
                    "url_pattern": "/posts?userId={id}",
                    "extra_config": {
                        "telemetry/opentelemetry": {
                            "backend": {
                                "metrics": {
                                    "static_attributes": [
                                        {
                                            "key": "my_metric_backend_override_attr",
                                            "value": "my_metric_backend_override_val"
                                        }
                                    ]
                                }
                            }
                        }
                    }
                
}
```

The backend will not have static attributes for traces, the values for the traces will be the defaults (**not the ones specified at the service level, inside layers**), for metrics , the _**roundtrip**_ , _**read_payload**_ , and _**detailed_connection**_ will be set to false.  


The example provided, even it was actually performing a mix of attributes for the `proxy` and the `backend` layers, is not documented in KrakenD Community Edition, and does not match the format of the KrakenD Enterprise Edition.

(Related PR: https://github.com/krakend/krakend-schema/pull/52 ) 

A part from fixing the example, we want to maintain the ability to add static attributes at the endpoint and backend levels (but the config parsing must change to match the Enterprise edition).

This is intended for a 2.8 release (since the current behaviour is not documented, we can change it as is an "undocumented feature) .

**Tested in Krakend CE**

With config : 

```json
{
  "$schema": "https://www.krakend.io/schema/v3.json",
  "version": 3,
  "name": "KrakenD Community API Gateway",
  "port": 8080,
  "host": ["http://fake_api"],
  "timeout": "3000ms",
  "cache_ttl": "300s",
  "endpoints": [
    {
      "@comment": "Feature: Aggregation + Basic transformation (filtering & mapping) + grouping",
      "endpoint": "/git/{user}",
      "backend": [
        {
          "host": ["https://api.github.com"],
          "url_pattern": "/users/{user}",
          "allow": [
            "avatar_url",
            "name",
            "company",
            "blog",
            "location",
            "mail",
            "hireable",
            "followers",
            "public_repos",
            "public_gists"
          ],
          "mapping": {
            "blog": "website"
          },
          "group": "user",
          "extra_config": {
             "telemetry/opentelemetry": {
                "backend": {
                    "traces": {
                        "static_attributes": [
                            {
                                "key": "a_git_key",
                                "value": "a_git_value"
                            }
                        ]
                    },
                    "metrics": {
                        "static_attributes": [
                            {
                                "key": "a_git_mt",
                                "value": "a_git_val"
                            }
                        ]
                    }
                }
             }
           }
        },
        {
          "host": ["https://api.github.com"],
          "url_pattern": "/users/{user}/repos",
          "mapping": {
            "collection": "repos"
          },
          "is_collection": true
        }
      ],
      "extra_config": {
        "telemetry/opentelemetry": {
            "proxy": {
                "disable_metrics": true,
                "report_headers": true,
                "traces_static_attributes": [
                    {
                        "key": "prx_k",
                        "value": "prx_val"
                    }
                ]
            }
        }
      }
    }
  ],
  "sequential_start": true,
  "extra_config": {
    "telemetry/logging": {
      "level": "DEBUG",
      "prefix": "[KRAKEND]",
      "syslog": false,
      "stdout": true
    },
    "telemetry/gelf": {
      "address": "logstash:12201",
      "enable_tcp": false
    },
    "security/cors": {
      "allow_origins": ["*"],
      "allow_methods": ["POST", "GET"],
      "allow_headers": ["Origin", "Authorization", "Content-Type"],
      "expose_headers": ["Content-Length"],
      "max_age": "12h"
    },
    "auth/revoker": {
      "N": 10000000,
      "P": 0.0000001,
      "hash_name": "optimal",
      "TTL": 1500,
      "port": 1234,
      "token_keys": ["jti"]
    },
    "telemetry/opentelemetry": {
        "service_name": "krakend_frontend_service",
        "metric_reporting_period": 1,
        "trace_sample_rate": 1,
        "exporters": { 
            "prometheus": [
                {
                    "name": "local_prometheus",
                    "port": 9090,
                    "process_metrics": true,
                    "go_metrics": true
                }
            ],
            "otlp": [
                {
                    "name": "local_tempo",
                    "host": "tempo",
                    "port": 4317,
                    "use_http": false,
                    "disable_metrics": true
                },
                {
                    "name": "local_jaeger",
                    "host": "jaeger",
                    "port": 4317,
                    "use_http": false,
                    "disable_metrics": true
                }
            ]
        },
        "layers": {
            "global": {
                "disable_metrics": false,
                "disable_traces": false,
                "disable_propagation": false,
                "report_headers": true
            },
            "proxy": {
                "disable_metrics": false,
                "disable_traces": false,
                "report_headers": true
            }, 
            "backend": {
                "metrics": {
                    "disable_stage": false,
                    "round_trip": true,
                    "read_payload": true,
                    "detailed_connection": true,
                    "static_attributes": [
                        {
                            "key": "my_metric_attr",
                            "value": "my_metric_val"
                        }
                    ]
                },
                "traces": {
                    "disable_stage": false,
                    "round_trip": true,
                    "read_payload": true,
                    "detailed_connection": true,
                    "static_attributes": [
                        {
                            "key": "my_trace_attr",
                            "value": "my_trace_val" 
                        }
                    ],
                    "report_headers": true
                }
            }
        }
    }
  }
}

```

In the above config we disable the details in tracing for the `/user/{user}` backend request, so it won't have extra spans, and we add an attribute `a_git_key=a_git_value` , and we also add at the proxy level `prx_k=prx_val` , so, it works as expected : 


![test_krakend_ce_overrides](https://github.com/user-attachments/assets/af9cec6c-b98f-483e-805c-fe7f499b60f0)


![screenshot_2024_10_24__09_53_50](https://github.com/user-attachments/assets/db1a0dc1-318d-4cef-a803-6021035247ec)
