### PR TITLE
fix: stop reporting metrics in client transport

### DIFF
--- a/http/client/transport.go
+++ b/http/client/transport.go
@@ -73,7 +73,7 @@ func readWrapperBuilder(metricsOpts *TransportMetricsOptions, tracesOpts *Transp
 ) readerWrapperFn {
 	if !metricsOpts.ReadPayload && !tracesOpts.ReadPayload {
 		// no metrics or traces for the payload reading
-		return func(r io.Reader, ctx context.Context) io.ReadCloser {
+		return func(r io.Reader, _ context.Context) io.ReadCloser {
 			rc, ok := r.(io.ReadCloser)
 			if !ok {
 				rc = io.NopCloser(r)

--- a/http/client/transport.go
+++ b/http/client/transport.go
@@ -124,8 +124,14 @@ func newTransport(base http.RoundTripper, metricsOpts TransportMetricsOptions,
 		return nil
 	}
 
-	meter := otelState.Meter()
-	tracer := otelState.Tracer()
+	var meter metric.Meter
+	if metricsOpts.Enabled() {
+		meter = otelState.Meter()
+	}
+	var tracer trace.Tracer
+	if tracesOpts.Enabled() {
+		tracer = otelState.Tracer()
+	}
 
 	return &Transport{
 		base:          base,


### PR DESCRIPTION
When there is no opentelemetry config provided, we default to report traces and metrics it there is an exporter configured. 
However, if some property of a config is provided, those reporting by default do not apply and you must explicitly set what you want to be reported. 

In the case of the transport, there was a bug, that was checking if either traces or metrics were enabled to instrument the client. That means that, if traces were enabled but not metrics, we would report both of them (or the other way around). 

That also leads to an "unexpected behaviour" : if we only configure static attributes (either for metrics or traces) and we do not set the other options, the config still results in not instrumenation enabled. And if we provide static_attributes for one of them (for example metrics) , it ends disables, but if we do not provide any configuration at all for the other (for example traces), due to this bug, the metrics get reported with the provided attributes. 

This fixes this behaviour. But still, it might be "unexpected" to provide static attributes, but having the instrumentation disabled for no providins something like `"round_trip": true` in the same config. 