### PR TITLE
fix: missing check for nil trace.Tracer

### DIFF
--- a/http/client/transport_traces.go
+++ b/http/client/transport_traces.go
@@ -37,6 +37,10 @@ type transportTraces struct {
 }
 
 func newTransportTraces(tracesOpts *TransportTracesOptions, tracer trace.Tracer, spanName string) *transportTraces {
+	if tracer == nil {
+		return nil
+	}
+
 	return &transportTraces{
 		tracer:             tracer,
 		spanName:           spanName,


### PR DESCRIPTION
Missing check for nil on newTransportTraces