### PR TITLE
chore: correctly parse metrics layer configuration

### DIFF
--- a/config/lura.go
+++ b/config/lura.go
@@ -63,20 +63,11 @@ func LuraExtraCfg(extraCfg luraconfig.ExtraConfig) (*ConfigData, error) {
 }
 
 func LuraLayerExtraCfg(extraCfg luraconfig.ExtraConfig) (*LayersOpts, error) {
-	tmp, ok := extraCfg[Namespace]
-	if !ok {
-		return nil, ErrNoConfig
-	}
+	cfg, err := LuraExtraCfg(extraCfg)
 
-	buf := new(bytes.Buffer)
-	if err := json.NewEncoder(buf).Encode(tmp); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
-	cfg := new(LayersOpts)
-	if err := json.NewDecoder(buf).Decode(cfg); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
+	return cfg.Layers, nil
 }

--- a/state/config_test.go
+++ b/state/config_test.go
@@ -66,7 +66,7 @@ func TestEndpointPipeNoOverride(t *testing.T) {
 		return
 	}
 
-	if len(pipeOpts.MetricsStaticAttributes) > 1 {
+	if len(pipeOpts.MetricsStaticAttributes) != 1 {
 		t.Errorf(
 			"Incorrect number of attributes for metrics. returned: %+v",
 			pipeOpts.MetricsStaticAttributes,
@@ -88,7 +88,7 @@ func TestEndpointPipeConfigOnlyOverride(t *testing.T) {
 
 	pipeOpts := stateCfg.EndpointPipeOpts(pipeCfg)
 
-	if len(pipeOpts.MetricsStaticAttributes) > 1 {
+	if len(pipeOpts.MetricsStaticAttributes) != 1 {
 		t.Errorf(
 			"Incorrect number of attributes for metrics. returned: %+v",
 			pipeOpts.MetricsStaticAttributes,
@@ -169,7 +169,7 @@ func TestBackendConfigNoOverride(t *testing.T) {
 		return
 	}
 
-	if len(backendOpts.Metrics.StaticAttributes) > 1 {
+	if len(backendOpts.Metrics.StaticAttributes) != 1 {
 		t.Errorf(
 			"Incorrect number of attributes for metrics. returned: %+v",
 			backendOpts.Traces.StaticAttributes,


### PR DESCRIPTION
## Description

It seems a small bug was introduced when `LuraLayerExtraCfg` function was created. As I understand it, it is trying to decode the `ExtraConfig` into a [`LayerOpts`](https://github.com/krakend/krakend-otel/blob/main/config/config.go#L130-L134) struct directly instead of into a [`ConfigData`](https://github.com/krakend/krakend-otel/blob/main/config/config.go#L11-L19) struct which is how the extra config for `krakend-otel` is defined. 

This is leading to an empty config which basically ignores the provided configuration as it receives each endpoint/backend configuration as input.

The tests were still passing as they didn't check for empty configs, so including that case into the tests (config length = 0) was enough to trigger the issue