### PR TITLE
add otel exporter option to override `metric_reporting_period`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,12 +108,13 @@ func (e *Exporters) Validate() error {
 }
 
 type OTLPExporter struct {
-	Name           string `json:"name"`
-	Host           string `json:"host"`
-	Port           int    `json:"port"`
-	UseHTTP        bool   `json:"use_http"`
-	DisableMetrics bool   `json:"disable_metrics"`
-	DisableTraces  bool   `json:"disable_traces"`
+	Name                        string `json:"name"`
+	Host                        string `json:"host"`
+	Port                        int    `json:"port"`
+	UseHTTP                     bool   `json:"use_http"`
+	DisableMetrics              bool   `json:"disable_metrics"`
+	DisableTraces               bool   `json:"disable_traces"`
+	CustomMetricReportingPeriod uint   `json:"custom_reporting_period"`
 }
 
 type PrometheusExporter struct {

--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,7 @@ type OTLPExporter struct {
 	UseHTTP                     bool   `json:"use_http"`
 	DisableMetrics              bool   `json:"disable_metrics"`
 	DisableTraces               bool   `json:"disable_traces"`
-	CustomMetricReportingPeriod uint   `json:"custom_reporting_period"`
+	CustomMetricReportingPeriod uint   `json:"custom_metric_reporting_period"`
 }
 
 type PrometheusExporter struct {

--- a/exporter/otelcollector/otelcollector.go
+++ b/exporter/otelcollector/otelcollector.go
@@ -21,10 +21,11 @@ import (
 
 // OtelCollector implements the traces exporter.
 type OtelCollector struct {
-	exporter                 sdktrace.SpanExporter
-	metricExporter           sdkmetric.Exporter
-	metricsDisabledByDefault bool
-	tracesDisabledByDefault  bool
+	exporter                    sdktrace.SpanExporter
+	metricExporter              sdkmetric.Exporter
+	metricsDisabledByDefault    bool
+	tracesDisabledByDefault     bool
+	customMetricReportingPeriod time.Duration
 }
 
 // SpanExporter implements the interface to export traces.
@@ -33,6 +34,9 @@ func (c *OtelCollector) SpanExporter() sdktrace.SpanExporter {
 }
 
 func (c *OtelCollector) MetricReader(reportingPeriod time.Duration) sdkmetric.Reader {
+	if c.customMetricReportingPeriod >= time.Second {
+		reportingPeriod = c.customMetricReportingPeriod
+	}
 	return sdkmetric.NewPeriodicReader(c.metricExporter,
 		sdkmetric.WithInterval(reportingPeriod))
 }
@@ -89,10 +93,11 @@ func httpExporterWithOptions(ctx context.Context, cfg config.OTLPExporter,
 	}
 
 	return &OtelCollector{
-		exporter:                 exporter,
-		metricExporter:           metricExporter,
-		metricsDisabledByDefault: cfg.DisableMetrics,
-		tracesDisabledByDefault:  cfg.DisableTraces,
+		exporter:                    exporter,
+		metricExporter:              metricExporter,
+		metricsDisabledByDefault:    cfg.DisableMetrics,
+		tracesDisabledByDefault:     cfg.DisableTraces,
+		customMetricReportingPeriod: time.Duration(cfg.CustomMetricReportingPeriod) * time.Second,
 	}, nil
 }
 
@@ -139,10 +144,11 @@ func grpcExporterWithOptions(ctx context.Context, cfg config.OTLPExporter,
 	}
 
 	return &OtelCollector{
-		exporter:                 exporter,
-		metricExporter:           metricExporter,
-		metricsDisabledByDefault: cfg.DisableMetrics,
-		tracesDisabledByDefault:  cfg.DisableTraces,
+		exporter:                    exporter,
+		metricExporter:              metricExporter,
+		metricsDisabledByDefault:    cfg.DisableMetrics,
+		tracesDisabledByDefault:     cfg.DisableTraces,
+		customMetricReportingPeriod: time.Duration(cfg.CustomMetricReportingPeriod) * time.Second,
 	}, nil
 }
 


### PR DESCRIPTION
In case we have multiple OTEL metric exporters, we might want to tweak the reporting period for each one of them. (For example, if one of those is reporting to our on premises instance with a lower retention period, and another is sent to an external provider with longer retention period, and might be some rate limit). 

With this PR, we add a `custom_metric_reporting_period` to the OTEL exporters config (docs about it here: https://www.krakend.io/docs/telemetry/opentelemetry/#exporters-otlp ) 

`custom_metric_reporting_period` : **unsigned integer** specifying the seconds to wait between sending report, `0` will not override the `metric_reporting_period` set for all metric exporters (https://www.krakend.io/docs/telemetry/opentelemetry/#metric_reporting_period) 

In order to easily check the reporting periods, I've created two otel exporters with addresses pointing to non-existing services, so we can see an error in the log, each time it tries to report the metrics:

- one at `localhost:5005` that should be reporting each 5 seconds (global configuration)
- one at `localhost:5011` that should be reporting each 11 seconds (overriden configuration)

```json
{
  "$schema": "https://www.krakend.io/schema/v3.json",
  "version": 3,
  "name": "My first API Gateway - KrakenD",
  "port": 8081,
  "host": ["http://my_service:8080"],
  "debug_endpoint": true,
  "extra_config": { 
    "telemetry/opentelemetry": {
      "service_name": "krakend_prometheus_service",
      "metric_reporting_period": 5,
      "trace_sample_rate": 1,
      "exporters": {
        "otlp": [
          {
            "disable_metrics": false,
            "disable_traces": true,
            "host": "localhost",
            "name": "five_seconds",
            "port": 5005,
            "use_http": true
          },
          {
            "disable_metrics": false,
            "disable_traces": true,
            "host": "localhost",
            "name": "eleven_seconds",
            "port": 5011,
            "use_http": true,
            "custom_metric_reporting_period": 11,
            "custom_reporting_period": 11
          }
        ]
      },
      "layers": {
        "global": {
          "disable_metrics": false,
          "disable_propagation": false,
          "disable_traces": false,
          "report_headers": true
        },
        "proxy": {
          "disable_metrics": false,
          "disable_traces": true,
          "report_headers": true
        },
        "backend": {
          "metrics": {
            "detailed_connection": true,
            "disable_stage": false,
            "read_payload": false,
            "round_trip": false
          },
          "traces": {
            "detailed_connection": false,
            "disable_stage": false,
            "read_payload": false,
            "report_headers": false,
            "round_trip": false
          }
        }
      }
    }
  },
  "endpoints": [
    {
      "endpoint": "/dashboard",
      "backend": [
        {
          "url_pattern": "/customer.json"
        },
        {
          "url_pattern": "/sales.json"
        }
      ]
    }
  ]
}

```

```
2025/03/03 09:58:56 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:01 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:02 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5011/v1/metrics": dial tcp 127.0.0.1:5011: connect: connection refused
2025/03/03 09:59:06 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:11 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:13 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5011/v1/metrics": dial tcp 127.0.0.1:5011: connect: connection refused
2025/03/03 09:59:16 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:21 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:24 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5011/v1/metrics": dial tcp 127.0.0.1:5011: connect: connection refused
2025/03/03 09:59:26 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:31 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
2025/03/03 09:59:35 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5011/v1/metrics": dial tcp 127.0.0.1:5011: connect: connection refused
2025/03/03 09:59:36 KRAKEND ERROR: [SERVICE: OpenTelemetry] failed to upload metrics: Post "https://localhost:5005/v1/metrics": dial tcp 127.0.0.1:5005: connect: connection refused
```