### PR TITLE
fix: apply with insecure to metrics exporter too

### DIFF
--- a/exporter/otelcollector/otelcollector.go
+++ b/exporter/otelcollector/otelcollector.go
@@ -68,12 +68,14 @@ func httpExporterWithOptions(ctx context.Context, cfg config.OTLPExporter,
 		switch u.Scheme {
 		case "http":
 			tOpts = append(tOpts, otlptracehttp.WithInsecure())
+			mOpts = append(mOpts, otlpmetrichttp.WithInsecure())
 			endpoint = u.Host
 		case "https":
 			endpoint = u.Host
 		}
 	} else {
 		tOpts = append(tOpts, otlptracehttp.WithInsecure())
+		mOpts = append(mOpts, otlpmetrichttp.WithInsecure())
 	}
 	tOpts = append(tOpts, otlptracehttp.WithEndpoint(endpoint))
 
@@ -119,12 +121,14 @@ func grpcExporterWithOptions(ctx context.Context, cfg config.OTLPExporter,
 		switch u.Scheme {
 		case "http":
 			tOpts = append(tOpts, otlptracegrpc.WithInsecure())
+			mOpts = append(mOpts, otlpmetricgrpc.WithInsecure())
 			endpoint = u.Host
 		case "https":
 			endpoint = u.Host
 		}
 	} else {
 		tOpts = append(tOpts, otlptracegrpc.WithInsecure())
+		mOpts = append(mOpts, otlpmetricgrpc.WithInsecure())
 	}
 	tOpts = append(tOpts, otlptracegrpc.WithEndpoint(endpoint))
 


### PR DESCRIPTION
When checking for the `http` vs `https` options, we are only applying the `WithInsecure` option to the traces exporter, but not the metrics one. 