### PR TITLE
add deployment env as attribute at the service level

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 type ConfigData struct {
 	ServiceName           string      `json:"service_name"`
 	ServiceVersion        string      `json:"service_version"`
+	DeployEnv             string      `json:"deploy_env"`
 	Layers                *LayersOpts `json:"layers"`
 	Exporters             Exporters   `json:"exporters"`
 	SkipPaths             []string    `json:"skip_paths"`


### PR DESCRIPTION
Add top level key for opentelemetry config, to set the **deployment environment**: `deploy_env` : 

https://github.com/krakend/krakend-otel/pull/54/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R14

```json
{
    "service_name": "playground_enterprise_otel",
    "deploy_env": "prod",
    "exporters": { ...}
}
```

![deployment_environment](https://github.com/user-attachments/assets/b04804f6-8627-4617-9954-e6b56e1f211b)
