### PR TITLE
client.address should honor trusted_proxies setting

### DIFF
--- a/http/attributes.go
+++ b/http/attributes.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/semconv/v1.21.0"
@@ -12,13 +13,43 @@ import (
 // it reports the url string with any variable parameter
 // that it might contain).
 func TraceRequestAttrs(r *http.Request) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, 5)
+	return TraceRequestAttrsWithTrustedProxies(r, nil)
+}
+
+func TraceRequestAttrsWithTrustedProxies(r *http.Request, trustedProxies map[string]bool) []attribute.KeyValue {
+
+	attrs := make([]attribute.KeyValue, 0, 8)
 	attrs = append(attrs,
 		semconv.URLFull(r.URL.String()),
 		semconv.ServerAddress(r.Host),
-		semconv.ClientAddress(r.RemoteAddr),
 		semconv.HTTPRequestMethodKey.String(r.Method),
 	)
+	clientAddr := r.RemoteAddr
+	if trustedProxies != nil {
+		vals, ok := r.Header["X-Forwarded-For"]
+		if !ok {
+			vals, ok = r.Header["X-Real-Ip"]
+		}
+		if ok && len(vals) > 0 {
+			s := strings.Split(vals[0], ",")
+			for i := len(s) - 1; i > 0; i-- {
+				ip := strings.TrimSpace(s[i])
+				if ok := trustedProxies[ip]; !ok {
+					// not trusted proxy ? might be client ip, we could
+					// check if is an actual ip by parsing it , but if
+					// it is spoofed by the client or some intermediate hop
+					// we can check it by looking at the X-Forwarded-For,
+					// or X-Real-Ip headers
+					clientAddr = ip
+					break
+				}
+			}
+			if clientAddr == r.RemoteAddr {
+				clientAddr = strings.TrimSpace(s[0])
+			}
+		}
+	}
+	attrs = append(attrs, semconv.ClientAddress(clientAddr))
 
 	if r.ContentLength >= 0 {
 		attrs = append(attrs, semconv.HTTPRequestBodySize(int(r.ContentLength)))

--- a/http/attributes.go
+++ b/http/attributes.go
@@ -36,7 +36,7 @@ func clientAddr(r *http.Request, trustedProxies map[string]bool) string {
 	if r.RemoteAddr == "" {
 		return ""
 	}
-	if trustedProxies == nil || len(trustedProxies) == 0 {
+	if len(trustedProxies) == 0 {
 		return r.RemoteAddr
 	}
 

--- a/http/attributes.go
+++ b/http/attributes.go
@@ -13,53 +13,61 @@ import (
 // it reports the url string with any variable parameter
 // that it might contain).
 func TraceRequestAttrs(r *http.Request) []attribute.KeyValue {
-	return TraceRequestAttrsWithTrustedProxies(r, nil)
-}
-
-func TraceRequestAttrsWithTrustedProxies(r *http.Request, trustedProxies map[string]bool) []attribute.KeyValue {
-
+	// we fill a max of 5 attributes, but 8 is a power of 2,
+	// and leaves room in the array to fill some extra args
+	// from the calling function.
 	attrs := make([]attribute.KeyValue, 0, 8)
 	attrs = append(attrs,
 		semconv.URLFull(r.URL.String()),
 		semconv.ServerAddress(r.Host),
 		semconv.HTTPRequestMethodKey.String(r.Method),
 	)
-	clientAddr := r.RemoteAddr
-	if trustedProxies != nil {
-		vals, ok := r.Header["X-Forwarded-For"]
-		if !ok {
-			vals, ok = r.Header["X-Real-Ip"]
-		}
-		if ok && len(vals) > 0 {
-			s := strings.Split(vals[0], ",")
-			for i := len(s) - 1; i > 0; i-- {
-				ip := strings.TrimSpace(s[i])
-				if ok := trustedProxies[ip]; !ok {
-					// not trusted proxy ? might be client ip, we could
-					// check if is an actual ip by parsing it , but if
-					// it is spoofed by the client or some intermediate hop
-					// we can check it by looking at the X-Forwarded-For,
-					// or X-Real-Ip headers
-					clientAddr = ip
-					break
-				}
-			}
-			if clientAddr == r.RemoteAddr {
-				clientAddr = strings.TrimSpace(s[0])
-			}
-		}
-	}
-	attrs = append(attrs, semconv.ClientAddress(clientAddr))
-
 	if r.ContentLength >= 0 {
 		attrs = append(attrs, semconv.HTTPRequestBodySize(int(r.ContentLength)))
 	}
-
 	userAgent := r.UserAgent()
 	if userAgent != "" {
 		attrs = append(attrs, semconv.UserAgentOriginal(userAgent))
 	}
+	return attrs
+}
 
+func clientAddr(r *http.Request, trustedProxies map[string]bool) string {
+	if r.RemoteAddr == "" {
+		return ""
+	}
+	if trustedProxies == nil || len(trustedProxies) == 0 {
+		return r.RemoteAddr
+	}
+
+	vals, ok := r.Header["X-Forwarded-For"]
+	if !ok {
+		vals, ok = r.Header["X-Real-Ip"]
+	}
+	if !ok || len(vals) == 0 {
+		return r.RemoteAddr
+	}
+
+	s := strings.Split(vals[0], ",")
+	for i := len(s) - 1; i > 0; i-- {
+		ip := strings.TrimSpace(s[i])
+		if ok := trustedProxies[ip]; !ok {
+			// not trusted proxy ? might be client ip, we could
+			// check if is an actual ip by parsing it , but if
+			// it is spoofed by the client or some intermediate hop
+			// we can check it by looking at the X-Forwarded-For,
+			// or X-Real-Ip headers
+			return ip
+		}
+	}
+	return strings.TrimSpace(s[0])
+}
+
+func TraceIncomingRequestAttrs(r *http.Request, trustedProxies map[string]bool) []attribute.KeyValue {
+	attrs := TraceRequestAttrs(r)
+	if cAddr := clientAddr(r, trustedProxies); cAddr != "" {
+		attrs = append(attrs, semconv.ClientAddress(cAddr))
+	}
 	return attrs
 }
 

--- a/http/attributes.go
+++ b/http/attributes.go
@@ -17,7 +17,6 @@ func TraceRequestAttrs(r *http.Request) []attribute.KeyValue {
 }
 
 func TraceRequestAttrsWithTrustedProxies(r *http.Request, trustedProxies map[string]bool) []attribute.KeyValue {
-
 	attrs := make([]attribute.KeyValue, 0, 8)
 	attrs = append(attrs,
 		semconv.URLFull(r.URL.String()),

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -92,7 +92,7 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 	if !gCfg.DisableTraces {
 		tracesAttrs := []attribute.KeyValue{attribute.String("krakend.stage", "global")}
 		for _, kv := range gCfg.TracesStaticAttributes {
-			if kv.Key != "" && kv.Value != "" > 0 {
+			if kv.Key != "" && kv.Value != "" {
 				tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
 			}
 		}

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -80,7 +80,7 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 	if !gCfg.DisableMetrics {
 		var metricsAttrs []attribute.KeyValue
 		for _, kv := range gCfg.MetricsStaticAttributes {
-			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+			if kv.Key != "" && kv.Value != "" {
 				metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
 			}
 		}
@@ -92,7 +92,7 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 	if !gCfg.DisableTraces {
 		tracesAttrs := []attribute.KeyValue{attribute.String("krakend.stage", "global")}
 		for _, kv := range gCfg.TracesStaticAttributes {
-			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+			if kv.Key != "" && kv.Value != "" > 0 {
 				tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
 			}
 		}

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -57,6 +57,10 @@ func (h *trackingHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 }
 
 func NewTrackingHandler(next http.Handler) http.Handler {
+	return NewTrackingHandlerWithTrustedProxies(next, nil)
+}
+
+func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []string) http.Handler {
 	otelCfg := state.GlobalConfig()
 	if otelCfg == nil {
 		return next
@@ -93,7 +97,7 @@ func NewTrackingHandler(next http.Handler) http.Handler {
 			}
 		}
 
-		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders)
+		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders, trustedProxies)
 	}
 
 	return &trackingHandler{

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -20,7 +20,8 @@ type tracesHTTP struct {
 }
 
 func newTracesHTTP(tracer trace.Tracer, attrs []attribute.KeyValue,
-	reportHeaders bool, trustedProxies []string) *tracesHTTP {
+	reportHeaders bool, trustedProxies []string,
+) *tracesHTTP {
 	var fa []attribute.KeyValue
 	if len(attrs) > 0 {
 		fa = make([]attribute.KeyValue, len(attrs))

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -51,11 +51,7 @@ func (t *tracesHTTP) start(r *http.Request, tr *tracking) *http.Request {
 	r = r.WithContext(tr.ctx)
 
 	var attrs []attribute.KeyValue
-	if len(t.trustedProxies) > 0 {
-		attrs = otelhttp.TraceRequestAttrsWithTrustedProxies(r, t.trustedProxies)
-	} else {
-		attrs = otelhttp.TraceRequestAttrs(r)
-	}
+	attrs = otelhttp.TraceIncomingRequestAttrs(r, t.trustedProxies)
 
 	tr.span.SetAttributes(attrs...)
 	if len(t.fixedAttrs) > 0 {

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -51,8 +51,7 @@ func (t *tracesHTTP) start(r *http.Request, tr *tracking) *http.Request {
 		trace.WithSpanKind(trace.SpanKindServer))
 	r = r.WithContext(tr.ctx)
 
-	var attrs []attribute.KeyValue
-	attrs = otelhttp.TraceIncomingRequestAttrs(r, t.trustedProxies)
+	attrs := otelhttp.TraceIncomingRequestAttrs(r, t.trustedProxies)
 
 	tr.span.SetAttributes(attrs...)
 	if len(t.fixedAttrs) > 0 {

--- a/lura/runserver.go
+++ b/lura/runserver.go
@@ -18,7 +18,13 @@ func GlobalRunServer(_ logging.Logger, next luragin.RunServerFunc) luragin.RunSe
 	}
 
 	return func(ctx context.Context, cfg luraconfig.ServiceConfig, h http.Handler) error {
-		wrappedH := kotelhttpserver.NewTrackingHandler(h)
+		var trustedProxies []string
+		if v, ok := cfg.ExtraConfig[luragin.Namespace].(map[string]interface{}); ok {
+			if tpxs, ok := v["trusted_proxies"].([]string); ok {
+				trustedProxies = tpxs
+			}
+		}
+		wrappedH := kotelhttpserver.NewTrackingHandlerWithTrustedProxies(h, trustedProxies)
 		return next(ctx, cfg, wrappedH)
 	}
 }


### PR DESCRIPTION
Fixes #33 

Support `X-Forwarded-For` and `X-Real-Ip` headers when the `trusted_proxies` values for gin's extra config is set. 

This should address the issue https://github.com/krakend/krakend-otel/issues/33  . Having had a look at the [OTEL semantic convention description for the `client.address` field](https://opentelemetry.io/docs/specs/semconv/attributes-registry/client/#client-address) it states that: 
> [1] client.address: When observed from the server side, and when communicating through an intermediary, client.address SHOULD represent the client address behind any intermediaries, for example proxies, if it’s available.

So, we add this to the **http server** incoming traces attributes. What I wonder is if we should really set that field in the spans for the backend requests (when Krakend acts as a client): given that those spans are childs of the incoming request main span, I am tempted to actually remove that attribute. 