### PR TITLE
Traces skip headers options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type GlobalOpts struct {
 	DisableTraces           bool       `json:"disable_traces"`
 	DisablePropagation      bool       `json:"disable_propagation"`
 	ReportHeaders           bool       `json:"report_headers"`
+	SkipHeaders             []string   `json:"skip_headers"`
 	MetricsStaticAttributes Attributes `json:"metrics_static_attributes"`
 	TracesStaticAttributes  Attributes `json:"traces_static_attributes"`
 	SemConv                 string     `json:"semantic_convention"`
@@ -155,6 +156,7 @@ type PipeOpts struct {
 	DisableMetrics          bool       `json:"disable_metrics"`
 	DisableTraces           bool       `json:"disable_traces"`
 	ReportHeaders           bool       `json:"report_headers"`
+	SkipHeaders             []string   `json:"skip_headers"`
 	MetricsStaticAttributes Attributes `json:"metrics_static_attributes"`
 	TracesStaticAttributes  Attributes `json:"traces_static_attributes"`
 }
@@ -255,6 +257,7 @@ type BackendTraceOpts struct {
 	DetailedConnection bool       `json:"detailed_connection"`
 	StaticAttributes   Attributes `json:"static_attributes"`
 	ReportHeaders      bool       `json:"report_headers"`
+	SkipHeaders        []string   `json:"skip_headers"`
 }
 
 // Enabled tells if there are any traces to be reported.

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -61,7 +61,7 @@ func NewTrackingHandler(next http.Handler) http.Handler {
 	return NewTrackingHandlerWithTrustedProxies(next, nil)
 }
 
-func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []string) http.Handler {
+func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []string) http.Handler { // skipcq: GO-R1005
 	otelCfg := state.GlobalConfig()
 	if otelCfg == nil {
 		return next

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -19,6 +19,7 @@ type trackingHandler struct {
 	metrics       *metricsHTTP
 	traces        *tracesHTTP
 	reportHeaders bool
+	skipHeaders   map[string]bool
 	config        state.Config
 }
 
@@ -40,7 +41,7 @@ func (h *trackingHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(t.ctx)
 
 	if h.metrics != nil || h.traces != nil {
-		rw = newTrackingResponseWriter(rw, t, h.reportHeaders, func(c net.Conn, _ error) (net.Conn, error) {
+		rw = newTrackingResponseWriter(rw, t, h.reportHeaders, h.skipHeaders, func(c net.Conn, _ error) (net.Conn, error) {
 			t.Finish()
 			h.traces.end(t)
 			h.metrics.report(t, r)
@@ -88,6 +89,14 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 		m = newMetricsHTTP(s.Meter(), metricsAttrs, gCfg.SemConv)
 	}
 
+	var sh map[string]bool
+	if len(gCfg.SkipHeaders) > 0 {
+		sh = make(map[string]bool, len(gCfg.SkipHeaders))
+		for _, v := range gCfg.SkipHeaders {
+			sh[v] = true
+		}
+	}
+
 	var t *tracesHTTP
 	if !gCfg.DisableTraces {
 		tracesAttrs := []attribute.KeyValue{attribute.String("krakend.stage", "global")}
@@ -97,7 +106,7 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 			}
 		}
 
-		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders, trustedProxies)
+		t = newTracesHTTP(s.Tracer(), tracesAttrs, gCfg.ReportHeaders, sh, trustedProxies)
 	}
 
 	return &trackingHandler{
@@ -106,6 +115,7 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 		metrics:       m,
 		traces:        t,
 		reportHeaders: gCfg.ReportHeaders,
+		skipHeaders:   sh,
 		config:        otelCfg,
 	}
 }

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -16,11 +16,12 @@ type tracesHTTP struct {
 	tracer         trace.Tracer
 	fixedAttrs     []attribute.KeyValue
 	reportHeaders  bool
+	skipHeaders    map[string]bool
 	trustedProxies map[string]bool
 }
 
 func newTracesHTTP(tracer trace.Tracer, attrs []attribute.KeyValue,
-	reportHeaders bool, trustedProxies []string,
+	reportHeaders bool, skipHeaders map[string]bool, trustedProxies []string,
 ) *tracesHTTP {
 	var fa []attribute.KeyValue
 	if len(attrs) > 0 {
@@ -36,6 +37,7 @@ func newTracesHTTP(tracer trace.Tracer, attrs []attribute.KeyValue,
 		tracer:         tracer,
 		fixedAttrs:     fa,
 		reportHeaders:  reportHeaders,
+		skipHeaders:    skipHeaders,
 		trustedProxies: tpm,
 	}
 }

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -96,9 +96,18 @@ func (t *tracesHTTP) end(tr *tracking) {
 	tr.span.SetAttributes(tr.tracesStaticAttrs...)
 
 	if tr.responseHeaders != nil {
-		// report all incoming headers
-		for hk, hv := range tr.responseHeaders {
-			tr.span.SetAttributes(attribute.StringSlice("http.response.header."+strings.ToLower(hk), hv))
+		if len(t.skipHeaders) == 0 {
+			// report all incoming headers
+			for hk, hv := range tr.responseHeaders {
+				tr.span.SetAttributes(attribute.StringSlice("http.response.header."+strings.ToLower(hk), hv))
+			}
+		} else {
+			for hk, hv := range tr.responseHeaders {
+				if !t.skipHeaders[hk] {
+					tr.span.SetAttributes(attribute.StringSlice("http.response.header."+strings.ToLower(hk), hv))
+				}
+			}
+
 		}
 	}
 	if len(tr.writeErrs) > 0 {

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -60,9 +60,17 @@ func (t *tracesHTTP) start(r *http.Request, tr *tracking) *http.Request {
 		tr.span.SetAttributes(t.fixedAttrs...)
 	}
 	if t.reportHeaders {
-		// report all incoming headers
-		for hk, hv := range r.Header {
-			tr.span.SetAttributes(attribute.StringSlice("http.request.header."+strings.ToLower(hk), hv))
+		if len(t.skipHeaders) == 0 {
+			// report all incoming headers
+			for hk, hv := range r.Header {
+				tr.span.SetAttributes(attribute.StringSlice("http.request.header."+strings.ToLower(hk), hv))
+			}
+		} else {
+			for hk, hv := range r.Header {
+				if !t.skipHeaders[hk] {
+					tr.span.SetAttributes(attribute.StringSlice("http.request.header."+strings.ToLower(hk), hv))
+				}
+			}
 		}
 	}
 	return r

--- a/http/server/traces.go
+++ b/http/server/traces.go
@@ -107,7 +107,6 @@ func (t *tracesHTTP) end(tr *tracking) {
 					tr.span.SetAttributes(attribute.StringSlice("http.response.header."+strings.ToLower(hk), hv))
 				}
 			}
-
 		}
 	}
 	if len(tr.writeErrs) > 0 {

--- a/lura/backend.go
+++ b/lura/backend.go
@@ -112,6 +112,7 @@ func InstrumentedHTTPClientFactory(clientFactory transport.HTTPClientFactory,
 			DetailedConnection: opts.Traces.DetailedConnection,
 			FixedAttributes:    traceAttrs,
 			ReportHeaders:      opts.Traces.ReportHeaders,
+			SkipHeaders:        opts.Traces.SkipHeaders,
 		},
 		OTELInstance: otelState,
 	}

--- a/lura/backend.go
+++ b/lura/backend.go
@@ -82,7 +82,7 @@ func InstrumentedHTTPClientFactory(clientFactory transport.HTTPClientFactory,
 
 	metricAttrs := attrs
 	for _, kv := range opts.Metrics.StaticAttributes {
-		if len(kv.Key) > 0 && len(kv.Value) > 0 {
+		if kv.Key != "" && kv.Value != "" {
 			metricAttrs = append(metricAttrs, attribute.String(kv.Key, kv.Value))
 		}
 	}
@@ -93,7 +93,7 @@ func InstrumentedHTTPClientFactory(clientFactory transport.HTTPClientFactory,
 	traceAttrs = append(traceAttrs,
 		attribute.String("krakend.stage", "backend-request"))
 	for _, kv := range opts.Traces.StaticAttributes {
-		if len(kv.Key) > 0 && len(kv.Value) > 0 {
+		if kv.Key != "" && kv.Value != "" {
 			traceAttrs = append(traceAttrs, attribute.String(kv.Key, kv.Value))
 		}
 	}

--- a/lura/proxy.go
+++ b/lura/proxy.go
@@ -124,13 +124,13 @@ func ProxyFactory(pf proxy.Factory) proxy.FactoryFunc {
 		metricsAttrs := attrs
 		tracesAttrs := attrs
 		for _, kv := range pipeOpts.MetricsStaticAttributes {
-			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+			if kv.Key != "" && kv.Value != "" {
 				metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
 			}
 		}
 
 		for _, kv := range pipeOpts.TracesStaticAttributes {
-			if len(kv.Key) > 0 && len(kv.Value) > 0 {
+			if kv.Key != "" && kv.Value != "" {
 				tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
 			}
 		}
@@ -176,7 +176,7 @@ func BackendFactory(bf proxy.BackendFactory) proxy.BackendFactory {
 		tracesAttrs := attrs
 		if backendOpts.Metrics != nil {
 			for _, kv := range backendOpts.Metrics.StaticAttributes {
-				if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				if kv.Key != "" && kv.Value != "" {
 					metricsAttrs = append(metricsAttrs, attribute.String(kv.Key, kv.Value))
 				}
 			}
@@ -186,7 +186,7 @@ func BackendFactory(bf proxy.BackendFactory) proxy.BackendFactory {
 		if backendOpts.Traces != nil {
 			reportHeaders = backendOpts.Traces.ReportHeaders
 			for _, kv := range backendOpts.Traces.StaticAttributes {
-				if len(kv.Key) > 0 && len(kv.Value) > 0 {
+				if kv.Key != "" && kv.Value != "" {
 					tracesAttrs = append(tracesAttrs, attribute.String(kv.Key, kv.Value))
 				}
 			}

--- a/lura/proxy_tracer.go
+++ b/lura/proxy_tracer.go
@@ -23,7 +23,8 @@ type middlewareTracer struct {
 }
 
 func newMiddlewareTracer(s state.OTEL, name string, stageName string, reportHeaders bool,
-	skipHeaders []string, attrs []attribute.KeyValue) *middlewareTracer {
+	skipHeaders []string, attrs []attribute.KeyValue,
+) *middlewareTracer {
 	tracer := s.Tracer()
 	if tracer == nil {
 		return nil


### PR DESCRIPTION
This PR introduces a new option to avoid reporting headers that might contain sensitive data: `skip_headers`. 

:warning: if the header must be removed from all layers, **it must be provided in each layer config**. 

Headers will not be reported for the request, nor the responses received.

Header names must be in canonical form ( `X-Api-Key` is ok, `x-api-key` is not ) . 

Tested with a header that should not be shown at any level (`X-All-Secret`) and set different headers to be ignored at each level (`global` , `proxy` and `backend` ):

```json
"layers": {
        "global": {
          "disable_metrics": false,
          "disable_propagation": false,
          "disable_traces": false,
          "report_headers": true,
          "skip_headers": [
              "X-Global-Secret",
              "X-All-Secret"
          ]
        },
        "proxy": {
          "disable_metrics": false,
          "disable_traces": false,
          "report_headers": true,
          "skip_headers": [
            "X-Proxy-Secret",
            "X-All-Secret"
          ]
        },
        "backend": {
          "metrics": {
            "detailed_connection": true,
            "disable_stage": false,
            "read_payload": true,
            "round_trip": true
          },
          "traces": {
            "detailed_connection": true,
            "disable_stage": false,
            "read_payload": true,
            "report_headers": true,
            "skip_headers": [
               "X-Backend-Secret",
               "X-All-Secret"
            ],
            "round_trip": true
          }
        }
      }
```

The globla level we can see that the `x-all-secret` is not reported, neither the `x-global-secret` : 

<img width="1127" height="614" alt="20250908_2027_screenshot" src="https://github.com/user-attachments/assets/7881d16c-d5c8-4158-9a2d-673fa33d5a59" />


For the proxy:

<img width="1098" height="623" alt="20250908_2028_screenshot" src="https://github.com/user-attachments/assets/f3803086-ea0f-4d6b-a2fa-a094f6deb950" />


And for the backend:

<img width="1028" height="1260" alt="20250908_2029_screenshot" src="https://github.com/user-attachments/assets/0446b009-5016-410d-bc63-0c10ef005d14" />


