### PR TITLE
fix: skip headers capitalization

### DIFF
--- a/http/client/transport_traces.go
+++ b/http/client/transport_traces.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http"
+	"net/textproto"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -46,7 +47,8 @@ func newTransportTraces(tracesOpts *TransportTracesOptions, tracer trace.Tracer,
 	if len(tracesOpts.SkipHeaders) > 0 {
 		sh = make(map[string]bool, len(tracesOpts.SkipHeaders))
 		for _, v := range tracesOpts.SkipHeaders {
-			sh[v] = true
+			canonical := textproto.CanonicalMIMEHeaderKey(v)
+			sh[canonical] = true
 		}
 	}
 	return &transportTraces{

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/textproto"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -93,7 +94,8 @@ func NewTrackingHandlerWithTrustedProxies(next http.Handler, trustedProxies []st
 	if len(gCfg.SkipHeaders) > 0 {
 		sh = make(map[string]bool, len(gCfg.SkipHeaders))
 		for _, v := range gCfg.SkipHeaders {
-			sh[v] = true
+			canonical := textproto.CanonicalMIMEHeaderKey(v)
+			sh[canonical] = true
 		}
 	}
 

--- a/lura/proxy_tracer.go
+++ b/lura/proxy_tracer.go
@@ -3,6 +3,7 @@ package lura
 import (
 	"context"
 	"errors"
+	"net/textproto"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -36,7 +37,8 @@ func newMiddlewareTracer(s state.OTEL, name string, stageName string, reportHead
 	if len(skipHeaders) > 0 {
 		sh = make(map[string]bool, len(skipHeaders))
 		for _, k := range skipHeaders {
-			sh[k] = true
+			canonical := textproto.CanonicalMIMEHeaderKey(k)
+			sh[canonical] = true
 		}
 	}
 	return &middlewareTracer{


### PR DESCRIPTION
Tested with and endpoint with `"input_headers": [ "*"]` and OTEL config, with headers defined in lowercase: 

```json
      "layers": {
        "global": {
          "disable_metrics": true,
          "disable_propagation": false,
          "disable_traces": false,
          "semantic_convention": "1.27",
          "report_headers": true,
          "skip_headers": ["x-priv-a", "X-priv-B"]
        },
        "proxy": {
          "disable_metrics": true,
          "disable_traces": false,
          "report_headers": true,
          "skip_headers": ["x-priv-a", "X-priv-B"]
        },
        "backend": {
          "metrics": {
            "detailed_connection": true,
            "static_attributes": [
              {
                "key": "attr_service_backend",
                "value": "service_level"
              }
            ]
          },
          "traces": {
            "detailed_connection": true,
            "disable_stage": false,
            "read_payload": true,
            "report_headers": true,
            "skip_headers": ["x-priv-a", "X-priv-B"],
            "round_trip": true
          }
        }
      }
```

Executing the curl command

```bash
$ curl -H 'X-Priv-A: mything' -H 'X-Pub: allow_this' localhost:7979/sometest 
{"message":"pong"}
```

And checked that `X-Priv-A` header does not appear in the traces:

<img width="1534" height="1615" alt="20251106_1823_screenshot" src="https://github.com/user-attachments/assets/5a3cbab1-3004-4485-b85b-0f3461a7054b" />
